### PR TITLE
Fix compiling errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ LDFLAGS		+=	-lbz2
 all:		bsdiff bspatch
 
 bsdiff:		bsdiff.o bsdifflib.o
-	$(CC) $(LDFLAGS) bsdiff.o bsdifflib.o -o $@
+	$(CC) bsdiff.o bsdifflib.o $(LDFLAGS) -o $@
 
 bspatch:	bspatch.o bspatchlib.o
-	$(CC) $(LDFLAGS) bspatch.o bspatchlib.o -o $@
+	$(CC) bspatch.o bspatchlib.o $(LDFLAGS) -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<

--- a/bspatchlib.c
+++ b/bspatchlib.c
@@ -33,7 +33,6 @@
 #include "bspatchlib.h"
 
 typedef unsigned char	u_char;
-typedef signed int		ssize_t;
 
 /***************************************************************************/
 


### PR DESCRIPTION
Related to change in makefile:
> Some time ago, gcc was changed to require libraries to occur after the code that used them. Once upon a time it didn't matter.
[by spjackson at December 12th, 2019](https://ubuntuforums.org/showthread.php?t=2432985&p=13916325#post13916325)

Related to change in code:
Probably this definition became a standard in one of the used libraries (not sure i'm new to C/C++) removing this fixed my second issue.